### PR TITLE
fix: duplicate year in footer

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -13,7 +13,7 @@
       <a>
         <span v-if="$themeConfig.author || $site.title">{{ $themeConfig.author || $site.title }}</span>
         &nbsp;&nbsp;
-        <span v-if="$themeConfig.startYear">{{ $themeConfig.startYear }} - </span>
+        <span v-if="$themeConfig.startYear && $themeConfig.startYear != year">{{ $themeConfig.startYear }} - </span>
         {{ year }}
       </a>
     </span>

--- a/components/Password.vue
+++ b/components/Password.vue
@@ -32,7 +32,7 @@
           <a>
             <span v-if="$themeConfig.author || $site.title">{{ $themeConfig.author || $site.title }}</span>
             &nbsp;&nbsp;
-            <span v-if="$themeConfig.startYear">{{ $themeConfig.startYear }} - </span>
+            <span v-if="$themeConfig.startYear && $themeConfig.startYear != year">{{ $themeConfig.startYear }} - </span>
             {{ year }}
           </a>
         </span>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- Thanks for your contribution. -->
<!-- So that we can understand your changes quickly, **please don't delete this template.** -->
<!-- To avoid wasting your time, if you need a new feature, it's best to open a feature request issue first and wait for approval before working on it. -->

**Summary**

Fix the display issue when `themeConfig.startYear` is this year. 

```
// before
2020 - 2020
// now
2020
```

**The PR fulfills these requirements:**

- [x] I confirm that I have been tested it.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI , please provide the **demo url** or **before/after screenshot**:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**
