### PR TITLE
Fix issues with mode switching and add modePicker config

### DIFF
--- a/components/Mode/ModePicker.vue
+++ b/components/Mode/ModePicker.vue
@@ -31,8 +31,9 @@ export default {
 
   mounted () {
     const mode = localStorage.getItem('mode')
-    const { mode: customizeMode } = this.$themeConfig
-    this.currentMode = mode ?? (customizeMode === null || customizeMode === undefined ? 'auto' : customizeMode)
+    const { mode: customizeMode, modePicker } = this.$themeConfig
+    const themeMode = customizeMode ?? 'auto'
+    this.currentMode = modePicker === false ? themeMode : mode ?? themeMode
     setMode(this.currentMode)
   },
 

--- a/components/Mode/ModePicker.vue
+++ b/components/Mode/ModePicker.vue
@@ -6,14 +6,14 @@
         v-for="(mode, index) in modeOptions"
         :key="index"
         :class="getClass(mode.mode)"
-        @click="selectMode(mode)"
+        @click="selectMode(mode.mode)"
       >{{ mode.title }}</li>
     </ul>
   </div>
 </template>
 
 <script>
-import setMode, { activateMode } from './setMode'
+import setMode from './setMode'
 
 export default {
   name: 'ModeOptions',
@@ -32,21 +32,17 @@ export default {
   mounted () {
     const mode = localStorage.getItem('mode')
     const { mode: customizeMode } = this.$themeConfig
-    this.currentMode = mode === null ? customizeMode === undefined ? 'auto' : customizeMode : mode
-    activateMode(this.currentMode)
+    this.currentMode = mode ?? (customizeMode === null || customizeMode === undefined ? 'auto' : customizeMode)
+    setMode(this.currentMode)
   },
 
   methods: {
     selectMode (mode) {
-      if (mode.mode === this.currentMode) {
-        return
-      } else if (mode.mode === 'auto') {
-        setMode()
-      } else {
-        activateMode(mode.mode)
+      if (mode !== this.currentMode) {
+        this.currentMode = mode
+        setMode(mode)
+        localStorage.setItem('mode', mode)
       }
-      localStorage.setItem('mode', mode.mode)
-      this.currentMode = mode.mode
     },
     getClass (mode) {
       return mode !== this.currentMode ? mode : `${mode} active`

--- a/components/Mode/setMode.js
+++ b/components/Mode/setMode.js
@@ -1,6 +1,6 @@
 import modeOptions from './modeOptions'
 
-export function activateMode (mode) {
+function activateMode (mode) {
   const rootElement = document.querySelector(':root')
   const options = modeOptions[mode]
 
@@ -9,19 +9,33 @@ export function activateMode (mode) {
   }
 }
 
+// Dark and Light autoswitches
+const onDark = (e) => e.matches && activateMode('dark')
+const onLight = (e) => e.matches && activateMode('light')
+
+const darkScheme = window.matchMedia('(prefers-color-scheme: dark)')
+const lightScheme = window.matchMedia('(prefers-color-scheme: light)')
+
 /**
  * Sets a color scheme for the website.
  * If browser supports "prefers-color-scheme" it will respect the setting for light or dark mode
  * otherwise it will set a dark theme during night time
  */
-export default function setMode () {
-  const isDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches
-  const isLightMode = window.matchMedia('(prefers-color-scheme: light)').matches
+export default function setMode (mode = 'auto') {
+  if (mode !== 'auto') {
+    darkScheme.removeListener(onDark)
+    lightScheme.removeListener(onLight)
+    activateMode(mode)
+    return
+  }
+
+  const isDarkMode = darkScheme.matches
+  const isLightMode = lightScheme.matches
   const isNotSpecified = window.matchMedia('(prefers-color-scheme: no-preference)').matches
   const hasNoSupport = !isDarkMode && !isLightMode && !isNotSpecified
 
-  window.matchMedia('(prefers-color-scheme: dark)').addListener(e => e.matches && activateMode('dark'))
-  window.matchMedia('(prefers-color-scheme: light)').addListener(e => e.matches && activateMode('light'))
+  darkScheme.addListener(onDark)
+  lightScheme.addListener(onLight)
 
   if (isDarkMode) activateMode('dark')
   if (isLightMode) activateMode('light')

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -22,7 +22,7 @@
         'max-width': linksWrapMaxWidth + 'px'
       } : {}">
 
-      <Mode v-show="$themeConfig.mode !== null" />
+      <Mode v-show="$themeConfig.modePicker !== false" />
       <AlgoliaSearchBox
         v-if="isAlgoliaSearch"
         :options="algolia"/>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- Thanks for your contribution. -->
<!-- So that we can understand your changes quickly, **please don't delete this template.** -->
<!-- To avoid wasting your time, if you need a new feature, it's best to open a feature request issue first and wait for approval before working on it. -->

**Summary**

3843aa3: fix: mode listeners not removed
- Refactor the mode setting and cache process
- Fix the problem that the event listener of color-scheme preference cannot be removed

2c93403: feat: add modePicker config
- Add a `modePicker` option in `themeConfig` to allow manually disabling the mode picker

**The PR fulfills these requirements:**

- [x] I confirm that I have been tested it.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI , please provide the **demo url** or **before/after screenshot**:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**

If mode picker is disabled, the site will always follow the default mode, instead of applying the cached mode in local storage. 