### PR TITLE
fix the sidebar title of beyond the current window that it follows th…

### DIFF
--- a/packages/vuepress-theme-reco/components/SidebarLinks.vue
+++ b/packages/vuepress-theme-reco/components/SidebarLinks.vue
@@ -52,8 +52,33 @@ export default {
       this.refreshIndex()
     }
   },
+  
+  mounted() {
+    this.isInViewPortOfOne()
+  },
+  
+  updated: function () {
+    this.isInViewPortOfOne()
+  },
 
   methods: {
+    isInViewPortOfOne () {
+        let siderbarScroll = document.getElementsByClassName("sidebar")[0]
+        let el = document.getElementsByClassName("active sidebar-link")[1]
+        if (el ==null || el.offsetTop == undefined) {
+          el = document.getElementsByClassName("active sidebar-link")[0]
+        }
+        if (el ==null || el.offsetTop == undefined) return
+        
+        const viewPortHeight = siderbarScroll.clientHeight || window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight 
+        let offsetBottom = el.offsetTop + el.offsetHeight
+        let scrollTop = siderbarScroll.scrollTop
+        let isView = (offsetBottom <= viewPortHeight + scrollTop)
+        if (!isView) {
+          siderbarScroll.scrollTop = (offsetBottom+5 - viewPortHeight)
+        }
+    },
+    
     refreshIndex () {
       const index = resolveOpenGroupIndex(
         this.$route,


### PR DESCRIPTION
After the title of the sidebar exceeds the current window, it does not automatically follow the document title to display in the current window.
See my blog post for the effect, try sliding your mouse: [https://zpj80231.github.io/znote/views/java/ThreadLocal.html](https://zpj80231.github.io/znote/views/java/ThreadLocal.html)

![GJ23VA.gif](https://s1.ax1x.com/2020/04/02/GJ23VA.gif)

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [X] Chrome 80.0.3987.149
- [ ] Firefox
- [ ] Safari
- [X] Edge 80.0.361.109
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
