### PR TITLE
带回车的span内容，会在前面自动生成一个空格

### DIFF
--- a/packages/vuepress-theme-reco/components/PageInfo.vue
+++ b/packages/vuepress-theme-reco/components/PageInfo.vue
@@ -25,9 +25,7 @@
         :key="subIndex"
         class="tag-item"
         :class="{ 'active': currentTag == subItem }"
-        @click="goTags(subItem)">
-        {{subItem}}
-      </span>
+        @click="goTags(subItem)">{{subItem}}</span>
     </i>
   </div>
 </template>


### PR DESCRIPTION
带回车的span内容，会在前面自动生成一个空格，当时移动端的时候，tag显示被换行下来，第一个tag内容前面就多了一个空格，与上一行没对齐

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- Thanks for your contribution. -->
<!-- So that we can understand your changes quickly, **please don't delete this template.** -->
<!-- To avoid wasting your time, if you need a new feature, it's best to open a feature request issue first and wait for approval before working on it. -->

**Summary**

<!-- Please describe your changes here. -->

**The PR fulfills these requirements:**

- [x] I confirm that I have been tested it.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI , please provide the **demo url** or **before/after screenshot**:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**
