### PR TITLE
Optimization: expand NoteAbstractItem click area

### DIFF
--- a/packages/vuepress-theme-reco/components/NoteAbstractItem.vue
+++ b/packages/vuepress-theme-reco/components/NoteAbstractItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="abstract-item"
-    @click="$router.push(item.path)">
+    @click.self="$router.push(item.path)">
     <i v-if="item.frontmatter.sticky" class="iconfont reco-sticky"></i>
     <div class="title">
       <i v-if="item.frontmatter.keys" class="iconfont reco-lock"></i>

--- a/packages/vuepress-theme-reco/components/NoteAbstractItem.vue
+++ b/packages/vuepress-theme-reco/components/NoteAbstractItem.vue
@@ -1,6 +1,7 @@
 <template>
   <div
-    class="abstract-item">
+    class="abstract-item"
+    @click="$router.push(item.path)">
     <i v-if="item.frontmatter.sticky" class="iconfont reco-sticky"></i>
     <div class="title">
       <i v-if="item.frontmatter.keys" class="iconfont reco-lock"></i>
@@ -36,6 +37,7 @@ export default {
   box-sizing: border-box;
   transition all .3s
   background-color var(--background-color)
+  cursor: pointer
   .reco-sticky
     position absolute
     top 0

--- a/packages/vuepress-theme-reco/components/PageInfo.vue
+++ b/packages/vuepress-theme-reco/components/PageInfo.vue
@@ -25,7 +25,7 @@
         :key="subIndex"
         class="tag-item"
         :class="{ 'active': currentTag == subItem }"
-        @click="goTags(subItem)">{{subItem}}</span>
+        @click.stop="goTags(subItem)">{{subItem}}</span>
     </i>
   </div>
 </template>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- Thanks for your contribution. -->
<!-- So that we can understand your changes quickly, **please don't delete this template.** -->
<!-- To avoid wasting your time, if you need a new feature, it's best to open a feature request issue first and wait for approval before working on it. -->

**Summary**

<!-- Please describe your changes here. -->

**The PR fulfills these requirements:**

- [x] I confirm that I have been tested it.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe:

扩大摘要卡片的可点击范围。卡片信息流布局在没有明显的按钮样式时，应尽可能让用户更方便地实现跳转，而不需要将鼠标移动到标题区域。根据用户收到的反馈，这个体验上的错愕感（不知道点哪里）在移动端上尤为明显。

If changing the UI , please provide the **demo url** or **before/after screenshot**:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**
