### PR TITLE
新增博客分页参数

### DIFF
--- a/packages/vuepress-theme-reco/components/HomeBlog.vue
+++ b/packages/vuepress-theme-reco/components/HomeBlog.vue
@@ -32,11 +32,13 @@
           <!-- 博客列表 -->
           <note-abstract
             :data="$recoPosts"
+            :perPage="getPerPage"
             :currentPage="currentPage"></note-abstract>
           <!-- 分页 -->
           <pagation
             class="pagation"
             :total="$recoPosts.length"
+            :perPage="getPerPage"
             :currentPage="currentPage"
             @getCurrentPage="getCurrentPage" />
         </div>
@@ -122,6 +124,9 @@ export default {
     },
     heroHeight () {
       return document.querySelector('.hero').clientHeight
+    },
+    getPerPage(){
+      return (this.$themeConfig.perPage && this.$themeConfig.perPage.blog && this.$themeConfig.perPage.blog > 0) ? this.$themeConfig.perPage.blog : 10
     }
   },
   mounted () {

--- a/packages/vuepress-theme-reco/components/NoteAbstract.vue
+++ b/packages/vuepress-theme-reco/components/NoteAbstract.vue
@@ -14,11 +14,11 @@ import NoteAbstractItem from './NoteAbstractItem'
 
 export default {
   components: { NoteAbstractItem },
-  props: ['data', 'currentPage', 'currentTag'],
+  props: ['data', 'currentPage', 'currentTag', 'perPage'],
   computed: {
     currentPageData () {
-      const start = this.currentPage * 10 - 10
-      const end = this.currentPage * 10
+      const start = this.currentPage * this.perPage - this.perPage
+      const end = this.currentPage * this.perPage
       return this.data.slice(start, end)
     }
   }

--- a/packages/vuepress-theme-reco/layouts/Category.vue
+++ b/packages/vuepress-theme-reco/layouts/Category.vue
@@ -22,6 +22,7 @@
         v-show="recoShowModule"
         class="list"
         :data="posts"
+        :perPage="getPerPage"
         :currentPage="currentPage"
         @currentTag="getCurrentTag"></note-abstract>
     </ModuleTransition>
@@ -31,6 +32,7 @@
       <pagation
         class="pagation"
         :total="posts.length"
+        :perPage="getPerPage"
         :currentPage="currentPage"
         @getCurrentPage="getCurrentPage"></pagation>
     </ModuleTransition>
@@ -67,6 +69,9 @@ export default {
     // 标题只显示分类名称
     title () {
       return this.$currentCategories.key
+    },
+    getPerPage(){
+      return (this.$themeConfig.perPage && this.$themeConfig.perPage.category && this.$themeConfig.perPage.category > 0) ? this.$themeConfig.perPage.category : 10
     }
   },
 

--- a/packages/vuepress-theme-reco/layouts/Tag.vue
+++ b/packages/vuepress-theme-reco/layouts/Tag.vue
@@ -16,6 +16,7 @@
         v-show="recoShowModule"
         class="list"
         :data="posts"
+        :perPage="getPerPage"
         :currentPage="currentPage"
         @currentTag="$currentTags.key"></note-abstract>
     </ModuleTransition>
@@ -25,6 +26,7 @@
       <pagation
         class="pagation"
         :total="posts.length"
+        :perPage="getPerPage"
         :currentPage="currentPage"
         @getCurrentPage="getCurrentPage"></pagation>
     </ModuleTransition>
@@ -58,6 +60,9 @@ export default {
       posts = filterPosts(posts)
       sortPostsByStickyAndDate(posts)
       return posts
+    },
+    getPerPage(){
+      return (this.$themeConfig.perPage && this.$themeConfig.perPage.tag && this.$themeConfig.perPage.tag > 0) ? this.$themeConfig.perPage.tag : 10
     }
   },
 

--- a/packages/vuepress-theme-reco/layouts/Tags.vue
+++ b/packages/vuepress-theme-reco/layouts/Tags.vue
@@ -14,6 +14,7 @@
         v-show="recoShowModule"
         class="list"
         :data="$recoPosts"
+        :perPage="getPerPage"
         :currentPage="currentPage"
         :currentTag="currentTag"
         @currentTag="getCurrentTag"></note-abstract>
@@ -24,6 +25,7 @@
       <pagation
         class="pagation"
         :total="$recoPosts.length"
+        :perPage="getPerPage"
         :currentPage="currentPage"
         @getCurrentPage="getCurrentPage"></pagation>
     </ModuleTransition>
@@ -47,6 +49,12 @@ export default {
       currentTag: '',
       currentPage: 1,
       allTagName: ''
+    }
+  },
+
+  computed:{
+    getPerPage(){
+      return (this.$themeConfig.perPage && this.$themeConfig.perPage.tag && this.$themeConfig.perPage.tag > 0) ? this.$themeConfig.perPage.tag : 10
     }
   },
 


### PR DESCRIPTION
**Summary**
**博客主题配置添加分页配置，具体参数如下**
```
 themeConfig: {
        perPage:{
            blog:5, //博客主页
            category:4,//分类
            tag:3,//标签页
        },
```
**说明：**
- 一直都不知道tag和tags的差别，此处`tag.vue`和`tags.vue`共用参数`perPage.tag`
- 三个参数的默认大小均为10
- 参数范围为[1,+∞)，小于1的参数取默认值。**没有做最大上限处理**

相关问题：Fixes #207 

**Demo:**
blog(参数为5): https://www.chanx.tech/
category(参数为4):  https://www.chanx.tech/categories/%E5%89%8D%E7%AB%AFfront-end/
tag(参数为3): https://www.chanx.tech/tag/
<!-- Please describe your changes here. -->

**The PR fulfills these requirements:**

- [ ] I confirm that I have been tested it.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

