### PR TITLE
fix: 修复frontmatter值转换的错误

### DIFF
--- a/packages/@vuepress-reco/plugin-page/src/node/Classifiable.ts
+++ b/packages/@vuepress-reco/plugin-page/src/node/Classifiable.ts
@@ -131,7 +131,8 @@ export default class Classifiable {
             {}
           )
         } else {
-          values?.forEach((value: ItemKey) => {
+          values?.map(value => String(value)).forEach((value: ItemKey) => {
+            if (value === '') return
             if (!this.classificationData[key].items[convertToPinyin(value)]) {
               this.classificationData[key].items[convertToPinyin(value)] = {
                 pages: [page],


### PR DESCRIPTION
**MR摘要**
修复frontmatter值转换的错误，拿categories和tags举例
```
categories:
 - false
 - undefined
 - null
 - 123
 - ''
 - 
tags:
 - false
 - undefined
 - null
 - 123
 - ''
 - 
 ```

**详细说明**
1. `纯数字`,`布尔值`,`undefined`,`null`,`不填写值`等情况会导致拼音转换错误，编译失败
```js
// 如null
TypeError: Cannot read properties of null (reading 'split')
    at Object.convertToPinyin (D:\front-end\vuepress-theme-reco\packages\@vuepress-reco\shared\lib\cjs\helpers\toPinYin.js:19:27) 
```

2. 空字符串可以通过拼音转换，但是会出现空tag，空category
![image](https://user-images.githubusercontent.com/48688440/166974761-6b453da8-c2bb-441d-8729-d061246010bf.png)
