### PR TITLE
fix(plugin-page): remove some warning while building

### DIFF
--- a/packages/@vuepress-reco/plugin-page/src/client/composable/usePageData.ts
+++ b/packages/@vuepress-reco/plugin-page/src/client/composable/usePageData.ts
@@ -9,10 +9,10 @@ export const postsSymbol = Symbol('postsSymbol')
 export const seriesSymbol = Symbol('seriesSymbol')
 
 export function usePageData(): Record<string, any> {
-  const categorySummary = inject(categorySummarySymbol) || {}
-  const posts = inject(postsSymbol) || []
-  const series = inject(seriesSymbol) || {}
-  const categoryPaginationPosts = inject(categoryPaginationPostsSymbol) || {}
+  const categorySummary = inject(categorySummarySymbol, null) || {}
+  const posts = inject(postsSymbol, null) || []
+  const series = inject(seriesSymbol, null) || {}
+  const categoryPaginationPosts = inject(categoryPaginationPostsSymbol, null) || {}
 
   if (!postsSymbol) {
     throw new Error('useSiteLocaleData() is called without provider.')


### PR DESCRIPTION
Remove '[Vue warn]: injection \"Symbol(XXX)\" not found' while building.

ISSUES CLOSED: #188